### PR TITLE
Prevent usage of @everyone as the mute role

### DIFF
--- a/GearBot/Cogs/Basic.py
+++ b/GearBot/Cogs/Basic.py
@@ -83,7 +83,7 @@ class Basic:
                         if attachment.isImage:
                             embed.set_image(url=attachment.url)
                         else:
-                            embed.add_field(name=Translator.translate("attachement_link", ctx), value=attachment.url)
+                            embed.add_field(name=Translator.translate("attachment_link", ctx), value=attachment.url)
                 try:
                     user = await commands.MemberConverter().convert(ctx, message.author)
                 except:

--- a/GearBot/Cogs/Basic.py
+++ b/GearBot/Cogs/Basic.py
@@ -74,7 +74,7 @@ class Basic:
                         if attachment.isImage:
                             embed.set_image(url=attachment.url)
                         else:
-                            embed.add_field(name=Translator.translate("attachement_link", ctx), value=attachment.url)
+                            embed.add_field(name=Translator.translate("attachment_link", ctx), value=attachment.url)
                 else:
                     description = message.content
                     embed = discord.Embed(colour=discord.Color(0xd5fff), description=description, timestamp=datetime.utcfromtimestamp(message.timestamp))

--- a/GearBot/Cogs/Serveradmin.py
+++ b/GearBot/Cogs/Serveradmin.py
@@ -154,6 +154,10 @@ class Serveradmin:
 
     @configure.command(aliases=["muterole"])
     async def mute_role(self, ctx:commands.Context, role:discord.Role):
+        """Prevent usage of @everyone as the mute role"""
+        if role == ctx.guild.default_role:
+            return await ctx.send(
+                f"{Emoji.get_chat_emoji('NO')} {Translator.translate(f'default_role_forbidden', ctx)}")
         """Sets what role to use for mutes"""
         guild:discord.Guild = ctx.guild
         perms = guild.me.guild_permissions


### PR DESCRIPTION
Same as #31 but with the mute role config.