### PR TITLE
[BUG FIX] Fix Discord Py Installation bug.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ certifi==2018.8.24
 cffi==1.11.5
 chardet==3.0.4
 cryptography==2.3.1
-discord.py==1.0.0a1551+g00a659c
+discord.py==0.16.12
 idna==2.7
 idna-ssl==1.1.0
 multidict==4.3.1


### PR DESCRIPTION
Your unable to install discord py through pip install -r requirements.txt, due to an error in the version checking/lookup.
By changing the format of the version checker (see changes) the command: ```pip install -r requirements.txt``` runs successfully.