### PR TITLE
Bold the username in role added

### DIFF
--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -233,7 +233,7 @@
   "command_usage": "Command usage: `{usage}`",
   "role_removed": "The ``{role}`` role was removed from **{user}** (``{user_id}``)",
   "role_removed_by": "The ``{role}`` role was removed from **{user}** (``{user_id}``) by {moderator} (``{moderator_id}``)",
-  "role_added": "The ``{role}`` role was added to {user} (``{user_id}``)",
+  "role_added": "The ``{role}`` role was added to **{user}** (``{user_id}``)",
   "role_added_by": "The ``{role}`` role was added to **{user}** (``{user_id}``) by {moderator} (``{moderator_id}``)",
   "nickname_changed": "{user} (``{user_id}``) has changed nickname from **``\u200b{before}\u200b``** to **``\u200b{after}\u200b``**",
   "own_nickname_changed": "{user} (``{user_id}``) has changed their own nickname from **``\u200b{before}\u200b``** to **``\u200b{after}\u200b``**",


### PR DESCRIPTION
Saw in the mod logs that a role was removed with the username bolded, then added with the username not-bolded which makes it to look off. So bolding the username to match the other role removal and additional logs.