### PR TITLE
✨ Handle system messages in modlogs

### DIFF
--- a/GearBot/Cogs/ModLog.py
+++ b/GearBot/Cogs/ModLog.py
@@ -116,10 +116,21 @@ class ModLog:
             name = Utils.clean_user(user) if hasUser else str(message.author)
             GearbotLogging.log_to(guild.id, "EDIT_LOGS",
                                   f"{Emoji.get_chat_emoji('TRASH')} {Translator.translate('message_removed', guild.id, name=name, user_id=user.id if hasUser else 'WEBHOOK', channel=channel.mention)}")
+            type_string = None
+            if message.type != None:
+                if message.type == MessageType.new_member.value:
+                    type_string = Translator.translate('system_message_new_member', guild)
+                elif message.type == MessageType.pins_add.value:
+                    type_string = Translator.translate('system_message_new_pin', guild)
+                else:
+                    type_string = Translator.translate('system_message_other', guild)
+
+                type_string = Translator.translate('system_message', guild, type = type_string)
             if Configuration.get_var(channel.guild.id, "EMBED_EDIT_LOGS"):
+                embed_content = type_string or message.content
 
                 embed = discord.Embed(timestamp=datetime.datetime.utcfromtimestamp(time.time()),
-                                      description=message.content)
+                                      description=embed_content)
                 embed.set_author(name=user.name if hasUser else message.author,
                                  icon_url=user.avatar_url if hasUser else EmptyEmbed)
 
@@ -129,8 +140,12 @@ class ModLog:
                                     value='\n'.join(attachment.url if hasattr(attachment, 'url') else attachment for attachment in message.attachments))
                 GearbotLogging.log_to(guild.id, "EDIT_LOGS", embed=embed)
             else:
-                cleaned_content = await Utils.clean(message.content, channel.guild)
-                GearbotLogging.log_to(guild.id, "EDIT_LOGS", f"**Content:** {cleaned_content}", can_stamp=False)
+                if type_string == None:
+                    cleaned_content = await Utils.clean(message.content, channel.guild)
+                    GearbotLogging.log_to(guild.id, "EDIT_LOGS", f"**Content:** {cleaned_content}", can_stamp=False)
+                else:
+                    GearbotLogging.log_to(guild.id, "EDIT_LOGS", type_string, can_stamp=False)
+
                 count = 1
                 for attachment in message.attachments:
                     GearbotLogging.log_to(guild.id, "EDIT_LOGS",

--- a/GearBot/Cogs/ModLog.py
+++ b/GearBot/Cogs/ModLog.py
@@ -129,6 +129,9 @@ class ModLog:
             if Configuration.get_var(channel.guild.id, "EMBED_EDIT_LOGS"):
                 embed_content = type_string or message.content
 
+                if len(embed_content) == 0:
+                    embed_content = Translator.translate('no_content_embed', guild)
+
                 embed = discord.Embed(timestamp=datetime.datetime.utcfromtimestamp(time.time()),
                                       description=embed_content)
                 embed.set_author(name=user.name if hasUser else message.author,
@@ -141,8 +144,9 @@ class ModLog:
                 GearbotLogging.log_to(guild.id, "EDIT_LOGS", embed=embed)
             else:
                 if type_string == None:
-                    cleaned_content = await Utils.clean(message.content, channel.guild)
-                    GearbotLogging.log_to(guild.id, "EDIT_LOGS", Translator.translate('content', guild, content=cleaned_content), can_stamp=False)
+                    if len(message.content) != 0:
+                        cleaned_content = await Utils.clean(message.content, channel.guild)
+                        GearbotLogging.log_to(guild.id, "EDIT_LOGS", Translator.translate('content', guild, content=cleaned_content), can_stamp=False)
                 else:
                     GearbotLogging.log_to(guild.id, "EDIT_LOGS", type_string, can_stamp=False)
 

--- a/GearBot/Cogs/ModLog.py
+++ b/GearBot/Cogs/ModLog.py
@@ -123,7 +123,7 @@ class ModLog:
                 elif message.type == MessageType.pins_add.value:
                     type_string = Translator.translate('system_message_new_pin', guild)
                 else:
-                    type_string = Translator.translate('system_message_other', guild)
+                    type_string = Translator.translate('system_message_unknown', guild)
 
                 type_string = Translator.translate('system_message', guild, type = type_string)
             if Configuration.get_var(channel.guild.id, "EMBED_EDIT_LOGS"):

--- a/GearBot/Cogs/ModLog.py
+++ b/GearBot/Cogs/ModLog.py
@@ -147,10 +147,15 @@ class ModLog:
                     GearbotLogging.log_to(guild.id, "EDIT_LOGS", type_string, can_stamp=False)
 
                 count = 1
+                multiple_attachments = len(message.attachments) > 1
                 for attachment in message.attachments:
-                    GearbotLogging.log_to(guild.id, "EDIT_LOGS",
-                                          f"**Attachment{f' {count}' if len(message.attachments) > 1 else ''}:** <{attachment.url if hasattr(attachment, 'url') else attachment}>",
-                                          can_stamp=False)
+                    attachment_url = attachment.url if hasattr(attachment, 'url') else attachment
+                    if multiple_attachments:
+                        attachment_str = Translator.translate('attachment_item', guild, num=count, attachment=attachment_url)
+                    else:
+                        attachment_str = Translator.translate('attachment_single', guild, attachment=attachment_url)
+
+                    GearbotLogging.log_to(guild.id, "EDIT_LOGS", attachment_str, can_stamp=False)
                     count += 1
 
     async def on_raw_message_edit(self, event: RawMessageUpdateEvent):

--- a/GearBot/Cogs/ModLog.py
+++ b/GearBot/Cogs/ModLog.py
@@ -134,7 +134,7 @@ class ModLog:
                 embed.set_author(name=user.name if hasUser else message.author,
                                  icon_url=user.avatar_url if hasUser else EmptyEmbed)
 
-                embed.set_footer(text=f"Sent in #{channel.name}")
+                embed.set_footer(text=Translator.translate('sent_in', guild, channel=channel.name))
                 if len(message.attachments) > 0:
                     embed.add_field(name=Translator.translate('attachment_link', guild),
                                     value='\n'.join(attachment.url if hasattr(attachment, 'url') else attachment for attachment in message.attachments))

--- a/GearBot/Cogs/ModLog.py
+++ b/GearBot/Cogs/ModLog.py
@@ -142,7 +142,7 @@ class ModLog:
             else:
                 if type_string == None:
                     cleaned_content = await Utils.clean(message.content, channel.guild)
-                    GearbotLogging.log_to(guild.id, "EDIT_LOGS", f"**Content:** {cleaned_content}", can_stamp=False)
+                    GearbotLogging.log_to(guild.id, "EDIT_LOGS", Translator.translate('content', guild, content=cleaned_content), can_stamp=False)
                 else:
                     GearbotLogging.log_to(guild.id, "EDIT_LOGS", type_string, can_stamp=False)
 

--- a/GearBot/Cogs/ModLog.py
+++ b/GearBot/Cogs/ModLog.py
@@ -4,7 +4,7 @@ import datetime
 import time
 
 import discord
-from discord import AuditLogAction, Role, DMChannel
+from discord import AuditLogAction, Role, DMChannel, MessageType
 from discord.embeds import EmptyEmbed
 from discord.raw_models import RawMessageDeleteEvent, RawMessageUpdateEvent
 
@@ -52,9 +52,15 @@ class ModLog:
                     logged = LoggedMessage.get_or_none(messageid=message.id)
                     fetch_times.append(time.perf_counter() - fetch)
                     if logged is None:
+                        message_type = message.type
+                        if message_type == MessageType.default:
+                            message_type = None
+                        else:
+                            message_type = message_type.value
                         LoggedMessage.create(messageid=message.id, author=message.author.id,
                                              content=message.content,
-                                             channel=channel.id, server=channel.guild.id)
+                                             channel=channel.id, server=channel.guild.id,
+                                             type=message_type)
                         for a in message.attachments:
                             LoggedAttachment.create(id=a.id, url=a.url,
                                                     isImage=(a.width is not None or a.width is 0),

--- a/GearBot/Util/MessageUtils.py
+++ b/GearBot/Util/MessageUtils.py
@@ -32,7 +32,9 @@ async def insert_message(bot, message):
     if is_cache_enabled(bot):
         pipe = bot.redis_pool.pipeline()
         pipe.hmset_dict(message.id, author=message.author.id, content=message.content,
-                         channel=message.channel.id, server=message.guild.id, attachments='|'.join((a.url for a in message.attachments)), type=message_type)
+                         channel=message.channel.id, server=message.guild.id, attachments='|'.join((a.url for a in message.attachments)))
+        if message_type != None:
+            pipe.hmset_dict(message.id, type=message_type)
         pipe.expire(message.id, 5*60+2)
         await pipe.execute()
     LoggedMessage.create(messageid=message.id, author=message.author.id, content=message.content,

--- a/GearBot/Util/MessageUtils.py
+++ b/GearBot/Util/MessageUtils.py
@@ -3,7 +3,7 @@ import time
 from collections import namedtuple
 from datetime import datetime
 
-from discord import Object, HTTPException
+from discord import Object, HTTPException, MessageType
 
 from Util import Translator, Emoji, Archive
 from database.DatabaseConnector import LoggedMessage, LoggedAttachment
@@ -30,8 +30,13 @@ async def insert_message(bot, message):
                          channel=message.channel.id, server=message.guild.id, attachments='|'.join((a.url for a in message.attachments)))
         pipe.expire(message.id, 5*60+2)
         await pipe.execute()
+    message_type = message.type
+    if message_type == MessageType.default:
+        message_type = None
+    else:
+        message_type = message_type.value
     LoggedMessage.create(messageid=message.id, author=message.author.id, content=message.content,
-                         channel=message.channel.id, server=message.guild.id)
+                         channel=message.channel.id, server=message.guild.id, type=message_type)
     for a in message.attachments:
         LoggedAttachment.create(id=a.id, url=a.url, isImage=(a.width is not None or a.width is 0),
                                 messageid=message.id)

--- a/GearBot/Util/MessageUtils.py
+++ b/GearBot/Util/MessageUtils.py
@@ -8,7 +8,7 @@ from discord import Object, HTTPException, MessageType
 from Util import Translator, Emoji, Archive
 from database.DatabaseConnector import LoggedMessage, LoggedAttachment
 
-Message = namedtuple("Message", "messageid author content channel server attachments")
+Message = namedtuple("Message", "messageid author content channel server attachments type")
 
 def is_cache_enabled(bot):
     return bot.redis_pool is not None
@@ -18,23 +18,23 @@ async def get_message_data(bot, message_id):
     if is_cache_enabled(bot) and not Object(message_id).created_at <= datetime.utcfromtimestamp(time.time() - 5 * 60):
         parts = await bot.redis_pool.hgetall(message_id)
         if len(parts) is 5:
-            message = Message(message_id, int(parts["author"]), parts["content"], int(parts["channel"]), int(parts["server"]), parts["attachments"].split("|") if len(parts["attachments"]) > 0 else [])
+            message = Message(message_id, int(parts["author"]), parts["content"], int(parts["channel"]), int(parts["server"]), parts["attachments"].split("|") if len(parts["attachments"]) > 0 else [], type=int(parts["type"]))
     if message is None:
         message = LoggedMessage.get_or_none(LoggedMessage.messageid == message_id)
     return message
 
 async def insert_message(bot, message):
-    if is_cache_enabled(bot):
-        pipe = bot.redis_pool.pipeline()
-        pipe.hmset_dict(message.id, author=message.author.id, content=message.content,
-                         channel=message.channel.id, server=message.guild.id, attachments='|'.join((a.url for a in message.attachments)))
-        pipe.expire(message.id, 5*60+2)
-        await pipe.execute()
     message_type = message.type
     if message_type == MessageType.default:
         message_type = None
     else:
         message_type = message_type.value
+    if is_cache_enabled(bot):
+        pipe = bot.redis_pool.pipeline()
+        pipe.hmset_dict(message.id, author=message.author.id, content=message.content,
+                         channel=message.channel.id, server=message.guild.id, attachments='|'.join((a.url for a in message.attachments)), type=message_type)
+        pipe.expire(message.id, 5*60+2)
+        await pipe.execute()
     LoggedMessage.create(messageid=message.id, author=message.author.id, content=message.content,
                          channel=message.channel.id, server=message.guild.id, type=message_type)
     for a in message.attachments:

--- a/GearBot/Util/MessageUtils.py
+++ b/GearBot/Util/MessageUtils.py
@@ -18,7 +18,7 @@ async def get_message_data(bot, message_id):
     if is_cache_enabled(bot) and not Object(message_id).created_at <= datetime.utcfromtimestamp(time.time() - 5 * 60):
         parts = await bot.redis_pool.hgetall(message_id)
         if len(parts) is 5:
-            message = Message(message_id, int(parts["author"]), parts["content"], int(parts["channel"]), int(parts["server"]), parts["attachments"].split("|") if len(parts["attachments"]) > 0 else [], type=int(parts["type"]))
+            message = Message(message_id, int(parts["author"]), parts["content"], int(parts["channel"]), int(parts["server"]), parts["attachments"].split("|") if len(parts["attachments"]) > 0 else [], type=int(parts["type"]) if "type" in parts else None)
     if message is None:
         message = LoggedMessage.get_or_none(LoggedMessage.messageid == message_id)
     return message

--- a/GearBot/database/DBFields.py
+++ b/GearBot/database/DBFields.py
@@ -1,0 +1,4 @@
+from peewee import IntegerField
+
+class TinyIntField(IntegerField):
+    field_type = 'TINYINT'

--- a/GearBot/database/DBUtils.py
+++ b/GearBot/database/DBUtils.py
@@ -1,14 +1,22 @@
 from peewee import IntegrityError
-
+from discord import MessageType
 from database.DatabaseConnector import LoggedMessage, LoggedAttachment
 
 
 def insert_message(message):
 
     try:
+        message_type = message.type
+
+        if message_type == MessageType.default:
+            message_type = None
+        else:
+            message_type = message_type.value
+
         logged = LoggedMessage.create(messageid=message.id, content=message.content,
                                    author=message.author.id,
-                                   channel=message.channel.id, server=message.guild.id)
+                                   channel=message.channel.id, server=message.guild.id,
+                                   type=message_type)
         for a in message.attachments:
             LoggedAttachment.create(id=a.id, url=a.url,
                                        isImage=(a.width is not None or a.width is 0),

--- a/GearBot/database/DatabaseConnector.py
+++ b/GearBot/database/DatabaseConnector.py
@@ -3,6 +3,8 @@ from peewee import *
 from Util import Configuration
 from Util.Enums import ReminderStatus
 
+from DBFields import TinyIntField
+
 connection = MySQLDatabase(Configuration.get_master_var("DATABASE_NAME"),
                            user=Configuration.get_master_var("DATABASE_USER"),
                            password=Configuration.get_master_var("DATABASE_PASS"),
@@ -23,14 +25,13 @@ class EnumField(IntegerField):
     def python_value(self, value):
         return self.choices(value)
 
-
 class LoggedMessage(Model):
     messageid = BigIntegerField(primary_key=True)
     content = CharField(max_length=2000, collation="utf8mb4_general_ci", null=True)
     author = BigIntegerField()
     channel = BigIntegerField()
     server = BigIntegerField()
-    type = BitField(null=True)
+    type = TinyIntField(null=True)
 
     class Meta:
         database = connection

--- a/GearBot/database/DatabaseConnector.py
+++ b/GearBot/database/DatabaseConnector.py
@@ -3,7 +3,7 @@ from peewee import *
 from Util import Configuration
 from Util.Enums import ReminderStatus
 
-from DBFields import TinyIntField
+from database.DBFields import TinyIntField
 
 connection = MySQLDatabase(Configuration.get_master_var("DATABASE_NAME"),
                            user=Configuration.get_master_var("DATABASE_USER"),

--- a/GearBot/database/DatabaseConnector.py
+++ b/GearBot/database/DatabaseConnector.py
@@ -30,6 +30,7 @@ class LoggedMessage(Model):
     author = BigIntegerField()
     channel = BigIntegerField()
     server = BigIntegerField()
+    type = BitField(null=True)
 
     class Meta:
         database = connection

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -620,5 +620,7 @@
   "system_message_new_member": "server join message",
   "system_message_new_pin": "pinned a message in the channel",
   "system_message_other": "other",
-  "system_message": "**System message**: {type}"
+  "system_message": "**System message**: {type}",
+  "attachment_item": "**Attachment #{num}**: {attachment}",
+  "attachment_single": "**Attachment**: {attachment}"
 }

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -119,6 +119,7 @@
   "message_removed": "Message by {name} (``{user_id}``) in {channel} has been removed.",
   "no_content": "no content",
   "sent_in": "Sent in {channel}",
+  "content": "**Content**: {content}",
   "before": "Before",
   "after": "After",
   "edit_logging": "Message by {user} (``{user_id}``) in {channel} has been edited.",

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -620,7 +620,7 @@
   "raid_mute_failed_no_role": "Failed to mute a raider, the server mute role is missing!",
   "system_message_new_member": "server join message",
   "system_message_new_pin": "pinned a message in the channel",
-  "system_message_other": "other",
+  "system_message_unknown": "unknown",
   "system_message": "**System message**: {type}",
   "attachment_item": "**Attachment #{num}**: {attachment}",
   "attachment_single": "**Attachment**: {attachment}"

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -615,5 +615,9 @@
   "raid_notification_forbidden": "Raid notification message failed to send: {user_name} (``{user_id}``) does not have DMs open or blocked me",
   "raid_shield_triggered": "A raid shield has been raised: **{name}**",
   "raid_shield_terminated": "A raid shield has lowered: **{name}**",
-  "raid_mute_failed_no_role": "Failed to mute a raider, the server mute role is missing!"
+  "raid_mute_failed_no_role": "Failed to mute a raider, the server mute role is missing!",
+  "system_message_new_member": "server join message",
+  "system_message_new_pin": "pinned a message in the channel",
+  "system_message_other": "other",
+  "system_message": "**System message**: {type}"
 }

--- a/lang/en_US.json
+++ b/lang/en_US.json
@@ -118,6 +118,7 @@
   "mute_negative_denied": "How do you expect me to mute for {duration}? I'm not a time traveler!",
   "message_removed": "Message by {name} (``{user_id}``) in {channel} has been removed.",
   "no_content": "no content",
+  "no_content_embed": "*Empty message*.",
   "sent_in": "Sent in {channel}",
   "content": "**Content**: {content}",
   "before": "Before",


### PR DESCRIPTION
🤔  Ever saw these strange empty message deletes from joins channel? Now you won't! ☝️  Introducing your our brand-new pull request that forever changes this: **Handle system messages in modlogs**. ✨ 

## In details:

- This PR makes GearBot record unusual message types in the database and further, according to those system message types, change appearance of the logged message deletion:

  ![unknown](https://user-images.githubusercontent.com/10401817/54081440-aa3e9080-4337-11e9-85e4-7a1558da720a.jpg)

- Furthermore I have discovered, that “content”, “sent in” and “attachment” strings were not translatable on deletions comparing to before/after strings for edits, so I fixed it too.

- For empty messages, GearBot not anymore logging their content or uses “*Empty message*.” line in embeds.

## Status

**PR**: This PR is review-ready.
**Testing**: According to my testing, these changes work correctly.

## Things to consider!

- String for pinned system message — “pinned a message in the channel,” probably needs to be changed:
  - pinned message in channel
  - pinned message
  - ???
