### PR TITLE
Use shorter Git Commit hash.

### DIFF
--- a/GearBot/Util/Utils.py
+++ b/GearBot/Util/Utils.py
@@ -211,5 +211,5 @@ def chunks(l, n):
         yield l[i:i+n]
 
 async def get_commit():
-    _, out, __ = await execute('git rev-parse HEAD')
+    _, out, __ = await execute('git rev-parse --short HEAD')
     return out.decode('utf-8')


### PR DESCRIPTION
This makes the version use the short git commit hash for the versioning, instead of the longer one.