### PR TITLE
Kick user from voice when they get muted.

### DIFF
--- a/GearBot/Cogs/Moderation.py
+++ b/GearBot/Cogs/Moderation.py
@@ -642,10 +642,10 @@ class Moderation(BaseCog):
                                 await target.add_roles(role, reason=Utils.trim_message(
                                     f"Moderator: {ctx.author.name}#{ctx.author.discriminator} ({ctx.author.id}) Reason: {reason}",
                                     500))
-                                try:
-                                    await target.move_to(None, reason=f"Moderator: {ctx.author.name}#{ctx.author.discriminator} ({ctx.author.id}) Reason: {reason}")
-                                except Forbidden:
-                                    pass
+                                if target.voice:
+                                    permissions = ctx.bot.permissions_in(target.voice.channel)
+                                    if permissions.move_members:
+                                        await target.move_to(None, reason=f"Moderator: {ctx.author.name}#{ctx.author.discriminator} ({ctx.author.id}) Reason: {reason}")
                                 until = time.time() + duration_seconds
                                 i = await InfractionUtils.add_infraction(ctx.guild.id, target.id, ctx.author.id, "Mute", reason,
                                                                end=until)

--- a/GearBot/Cogs/Moderation.py
+++ b/GearBot/Cogs/Moderation.py
@@ -642,6 +642,10 @@ class Moderation(BaseCog):
                                 await target.add_roles(role, reason=Utils.trim_message(
                                     f"Moderator: {ctx.author.name}#{ctx.author.discriminator} ({ctx.author.id}) Reason: {reason}",
                                     500))
+                                try:
+                                    await target.move_to(None, reason=f"Moderator: {ctx.author.name}#{ctx.author.discriminator} ({ctx.author.id}) Reason: {reason}")
+                                except Forbidden:
+                                    pass
                                 until = time.time() + duration_seconds
                                 i = await InfractionUtils.add_infraction(ctx.guild.id, target.id, ctx.author.id, "Mute", reason,
                                                                end=until)


### PR DESCRIPTION
**What does this PR add/fix/improve/...**
Since Discord requires a user to leave a voice channel for new voice permissions to go into effect the mute command now automatically kicks a user from voice so they're unable to speak.