### PR TITLE
Changed role listing of "serverinfo" to inline=False

### DIFF
--- a/GearBot/Util/server_info.py
+++ b/GearBot/Util/server_info.py
@@ -47,7 +47,7 @@ def server_info_embed(guild, request_guild=None):
     embed.add_field(
         name=Translator.translate('all_roles', request_guild),
         value=roles if len(roles) < 1024 else f"{len(guild.roles)} roles",
-        inline=True
+        inline=False
     )
 
     if guild.emojis:


### PR DESCRIPTION
**What does this PR add/fix/improve/...**
Adjusts the "serverinfo" command to forcing the inline of roles to false.
This is done to better support servers of which have more than a few roles.

**Migration**
N/A

**Dependencies**
N/A
