### PR TITLE
Add Threads support for `archive channel`

### DIFF
--- a/GearBot/Bot/TheRealGearBot.py
+++ b/GearBot/Bot/TheRealGearBot.py
@@ -208,7 +208,7 @@ async def on_command_error(bot, ctx: commands.Context, error):
     elif isinstance(error, PostParseError):
         bot.help_command.context = ctx
         await send(ctx, f"{Emoji.get_chat_emoji('NO')} {Translator.translate('bad_argument', ctx, type=error.type, error=Utils.replace_lookalikes(str(error.error)))}\n{Emoji.get_chat_emoji('WRENCH')} {Translator.translate('command_usage', ctx, usage=bot.help_command.get_command_signature(ctx.command))}")
-    elif isinstance(error, commands.BadArgument):
+    elif isinstance(error, (commands.BadArgument, commands.BadUnionArgument)):
         param = list(ctx.command.params.values())[min(len(ctx.args) + len(ctx.kwargs), len(ctx.command.params))]
         bot.help_command.context = ctx
         await send(ctx, f"{Emoji.get_chat_emoji('NO')} {Translator.translate('bad_argument', ctx, type=param._name, error=Utils.replace_lookalikes(str(error)))}\n{Emoji.get_chat_emoji('WRENCH')} {Translator.translate('command_usage', ctx, usage=bot.help_command.get_command_signature(ctx.command))}")

--- a/GearBot/Cogs/Moderation.py
+++ b/GearBot/Cogs/Moderation.py
@@ -1203,7 +1203,7 @@ class Moderation(BaseCog):
                 f"{Emoji.get_chat_emoji('NO')} {Translator.translate('archive_no_subcommand', ctx, prefix=ctx.prefix)}")
 
     @archive.command()
-    async def channel(self, ctx, channel: disnake.TextChannel = None, amount=100):
+    async def channel(self, ctx, channel: typing.Union[disnake.TextChannel, disnake.Thread] = None, amount=100):
         """archive_channel_help"""
         if amount > 5000:
             await ctx.send(f"{Emoji.get_chat_emoji('NO')} {Translator.translate('archive_too_much', ctx)}")


### PR DESCRIPTION
This includes Posts in Forum Channels as well, since Posts are Threads,

**What does this PR add/fix/improve/...**
The  `!archive channel` command now supports Threads and Forum Channel Posts.

**Migration**
No

**Dependencies**
Not Applicable
